### PR TITLE
update framework dependency to ~3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=5.3.2",
         "composer/installers": "*",
-        "silverstripe/framework": "3.1.*"
+        "silverstripe/framework": "~3.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Allows this module to be installed with SS 3.2. I'm currently running it on 3.2. and seems fine, if you could merge and release that would be great!