### PR TITLE
Add ability to exclude a header by leaving the value empty in yml (SS4)

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,6 +1,6 @@
 ---
 Name: security-headers
-After: 'framework/*, cms/*'
+After: 'coreconfig'
 ---
 Guttmann\SilverStripe\SecurityHeaderControllerExtension:
   headers:

--- a/src/SecurityHeaderControllerExtension.php
+++ b/src/SecurityHeaderControllerExtension.php
@@ -16,6 +16,10 @@ class SecurityHeaderControllerExtension extends Extension
         $xHeaderMap = (array) Config::inst()->get('Guttmann\SilverStripe\SecurityHeaderControllerExtension', 'x_headers_map');
 
         foreach ($headersToSend as $header => $value) {
+            if (empty($value)) {
+                continue;
+            }
+
             if ($header === 'Content-Security-Policy' && !$this->browserHasWorkingCSPImplementation()) {
                 continue;
             }


### PR DESCRIPTION
Adds ability to 'disable' a security header, by leaving the value in yml as "". Otherwise there is no way to override what has been set in the module's yml